### PR TITLE
Readme: Recommend to use stable release prefer to dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ PHP wrapper pro práci s Ecomail.cz API
 # Instalace
 
 ```
-composer require ecomailcz/ecomail:dev-master
+composer require ecomailcz/ecomail
 ```
 
 # Použití


### PR DESCRIPTION
Vzhledem k tomu, že vyšla verze `v1.0`, není důvod doporučovat v `README.md` instalaci z `dev-master`.