### PR TITLE
Composer: Autoload files by classmap instead of PSR-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,7 @@
     "phpstan/phpstan": "^0.12.9"
   },
   "autoload": {
-    "psr-4": {
-      "": "src/"
-    }
+    "classmap": ["src/"]
   },
   "scripts": {
     "phpstan": "vendor/bin/phpstan analyse --level 5 src/"


### PR DESCRIPTION
Pokud se tato knihovna přidá do většího projektu, kde je více dalších knihoven, je nevhodné používat `PSR-4` v okamžiku, kdy k tomu knihovna není uzpůsobena, neboť sama nepoužívá jmenné prostory. Hledání knihovny v celém jmenném prostoru je v takové situaci velmi neefektivní.

Proto je lepší použít `classmap`. Ten má nevýhodu, že při přidání nového souboru je potřeba zavolat `composer install`, ale to v případě knihovny bezpřednětné – s tím se potká pouze vývojář, který tento balíček vyvíjí, nikoliv jeho uživatelé, kteří si jej přes Composer načítají.