### PR TITLE
Composer: Declare platform dependency on PHP extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,9 @@
     }
   ],
   "require": {
-    "php": ">=5.3.2"
+    "php": ">=5.3.2",
+    "ext-curl": "*",
+    "ext-json": "*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Protože knihovna uvnitř používá PHP rozšíření `cURL` a `JSON`, je vhodné takto označit vnitřní závislost knihovny, aby se to propsalo do požadavků aplikace, která takovou knihovnu používá.

See more: https://getcomposer.org/doc/01-basic-usage.md#platform-packages