### PR TITLE
Git: Ignore dev-based composer's files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/composer.lock
+/vendor/


### PR DESCRIPTION
Je vhodné definovat, že by se `vendor/` a `composer.lock` neměly dostat do repozitáře – tyto jsou vhodné pouze během vývoje knihovny.