### PR TITLE
Git: Prevent to export dev-only files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+example export-ignore


### PR DESCRIPTION
Příklady v `examples/` a soubor `.gitginore` soubory se použijí pouze pokud uživatel pracuje s knihovnou samostatně, nebo když se tato vyvíjí. Jakmile je ale nasadí do přes Composer do projektu, jsou tyto soubory nepotřebné, zbytečně se pak vláží na produkci a je vhodné je při exportování do Packagistu ignorovat.

