### PR TITLE
Composer: Add PhpStan testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,15 @@
   "require": {
     "php": ">=5.3.2"
   },
+  "require-dev": {
+    "phpstan/phpstan": "^0.12.9"
+  },
   "autoload": {
     "psr-4": {
       "": "src/"
     }
+  },
+  "scripts": {
+    "phpstan": "vendor/bin/phpstan analyse --level 5 src/"
   }
 }


### PR DESCRIPTION
Navrhuji přidáni [PhpStanu](https://github.com/phpstan/phpstan#readme) jako dev-závisosti (tato se nepropaguje do projektů, které knihovnu použijí).

Pro spuštění testu zavolejte:
`composer install --dev`
`composer run phpstan`

PhpStan je nyní nataven na `level 5` a všechny chyny do této úrovně jsou opravené v PR #13.

POZOR: Tento PR bude pravděpodobně konfliktní s PR #9. Prosím nejdříve o merge #9, v případě konfliktu pošlu opravu.