### PR TITLE
Composer: Make Description more globally understandable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "ecomailcz/ecomail",
-  "description": "API Wrapper",
+  "description": "Ecomail.cz API Wrapper",
   "license": "GNU GPL 3",
   "version": "1.1",
   "keywords": ["API", "Wrapper", "Ecomail", "Newsletter", "Email", "Marketing"],


### PR DESCRIPTION
Stávající popis pluginu: `API Wrapper` je použitelný jen v kontextu pluginu, ale v přehledu balíčků je nicneříkající.

![composer show](https://cdn.jakub-boucek.cz/screenshot/200207-lmt7k.png)

PR tedy přidává jméno služby do popisu: `Ecomail.cz API Wrapper`