### PR TITLE
Composer: Remove version & time from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,8 @@
   "name": "ecomailcz/ecomail",
   "description": "API Wrapper",
   "license": "GNU GPL 3",
-  "version": "1.1",
   "keywords": ["API", "Wrapper", "Ecomail", "Newsletter", "Email", "Marketing"],
   "type": "library",
-  "time": "2016-10-04",
   "authors": [
     {
       "name": "Filip Šedivý",


### PR DESCRIPTION
Verzování v `composer.json` je zavádějící a zjevně neudržované, protože se vývojem balíčku nezvyšuje. Je tedy adept na odebrání a ponechání řízení verzí na tagování Gitem.

Přehled verzí generovaných podle Gitu: https://github.com/Ecomailcz/ecomail-php/releases

Dokumentace ke schématu:
- `time`: https://getcomposer.org/doc/04-schema.md#time
- `version`: https://getcomposer.org/doc/04-schema.md#version