### PR TITLE
Fix Bad condition on response format issue (#7)

### DIFF
--- a/src/Ecomail.php
+++ b/src/Ecomail.php
@@ -442,7 +442,7 @@ class Ecomail
         switch ($this->response) {
             case self::JSONArray:
             case self::JSONObject:
-                if (is_object(json_decode($output))) {
+                if (is_array(json_decode($output, true))) {
                     $output = json_decode($output, $this->response == self::JSONObject ? false : true);
                 }
                 break;


### PR DESCRIPTION
**Fixes Bad condition on response format issue (#7)**

@Degee was right, when response item was wrapped inside `[]`, condition missed, because json_decode return content wrapped into `array` instead of `object` type.

```php
var_dump(json_decode('[{"a":"b"},{"c":"d"}]'));
```

```
array(2) {
  [0] =>
  class stdClass#1 (1) {
    public $a =>
    string(1) "b"
  }
  [1] =>
  class stdClass#2 (1) {
    public $c =>
    string(1) "d"
  }
}

```

This PR is switch condition to `array`-based which matches both of response types.

IMPORTANT: I don't know reasons why this lib allows return responses as `stdClass` and I don't know all consequences about `stdClass`. Please test this PR well before merge it!

Resolves #7 