### PR TITLE
Added more info when request failed

### DIFF
--- a/src/Ecomail.php
+++ b/src/Ecomail.php
@@ -456,9 +456,15 @@ class Ecomail
         // Check HTTP status code
         if (!curl_errno($ch)) {
             $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            $content_type = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
+            $error_message_is_json = $content_type === 'application/json';
+            if ($error_message_is_json) {
+                $output = json_decode($output, null, $options);
+            }
             if ($http_code < 200 || $http_code > 299) {
                 return array(
                     'error' => $http_code,
+                    'message' => $output,
                 );
             }
         }


### PR DESCRIPTION
This PR has not BC break.

**Why do it?**
When user (programmer) send incorrect request than he isn't feedback what is bad. Example:

```
var_dump($ecoMail->sendTransactionalTemplate([
    'template_id' => 1,
    'to' => [
        'email' => 'customer@domain.tld',
    ],
]));
```

**The current output is:**
```
array(1) {
  ["error"]=>
  int(400)
}
```

Okey.. something is bad. But what? Incorrect data? Expired account? Something in network? Some else?

**Output after small change in this PR:**
```
array(2) {
  ["error"]=>
  int(400)
  ["message"]=>
  string(166) "{"message":["The message field is required."],"message.template_id":["The message.template id field is required."],"message.to":["The message.to field is required."]}"
}
```

What do you mean?  :)