### PR TITLE
Add paginator

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,24 @@
 
 # Instalace
 
-```
+```shell
 composer require ecomailcz/ecomail
 ```
 
 # Použití
 
-```
+```php
 $ecomail = new Ecomail('API_KEY');
 $ecomail->getListsCollection();
 ```
+
+Pokud bude server vracet větší množství položek v seznamu, může být odpověď rozdělena do více stránek. Počet dostupných
+stránek server posílá v odpovědi v parametru `last_page`. Pro přístup k dalším stránkám nastavte službě požadovanou stránku:
+
+```php
+$ecomail->page(2)->getListsCollection();
+```
+
 
 API klíč naleznete v nastavení vašeho účtu v sekci integrace.
 


### PR DESCRIPTION
PR reaguje na #26, doplňuje možnost číst ze serveru stránkované seznamy.

Protože na to není služba nijak připravena a vrací jen mrtvá data (tj, pole/`stdClass`, nikoliv rozšiřitelný response objekt), nebylo moc jak jinak přidat stránkovatelnost, aniž by se otocky přidal parametr do každé volací metody.

## Použití

```php
$ecomail = new Ecomail('API_KEY');

// page 1
$subscribers = $ecomail->getSubscribers($listId);

// page 2
$subscribers = $ecomail->page(2)->getSubscribers($listId);

// page 3
$subscribers = $ecomail->page(3)->getSubscribers($listId);
```

## Použití ve smyčce

```php
$ecomail = new Ecomail('API_KEY');

$response = $ecomail->getSubscribers($listId);
$pages = $response['last_page'];

$subscribers = $response['data'];

for ($page = 2; $page <= $pages; $page++) {
    $response = $ecomail->page($page)->getSubscribers($listId);
    $subscribers = array_merge($subscribers, $response['data']);
}
```

Dokumentace (Readme) doplněna o příklad.

Closes #26 