### PR TITLE
Fix invalid output handling

### DIFF
--- a/src/Ecomail.php
+++ b/src/Ecomail.php
@@ -533,7 +533,7 @@ class Ecomail
             )
         );
 
-        $output = curl_exec($ch);
+        $raw_output = $output = curl_exec($ch);
 
         // Check HTTP status code
         if (!curl_errno($ch)) {
@@ -541,12 +541,12 @@ class Ecomail
             $content_type = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
             $error_message_is_json = $content_type === 'application/json';
             if ($error_message_is_json) {
-                $output_decoded = json_decode($output, null, 512, $json_options);
+                $output = json_decode($raw_output, null, 512, $json_options);
             }
             if ($http_code < 200 || $http_code > 299) {
                 return array(
                     'error' => $http_code,
-                    'message' => $output_decoded,
+                    'message' => $output,
                 );
             }
         }
@@ -556,12 +556,12 @@ class Ecomail
         switch ($this->response) {
             case self::JSONArray:
             case self::JSONObject:
-                if (is_array(json_decode($output, true))) {
-                    $output = json_decode($output, $this->response !== self::JSONObject);
+                if (is_array(json_decode($raw_output, true))) {
+                    $raw_output = json_decode($raw_output, $this->response !== self::JSONObject);
                 }
                 break;
         }
 
-        return $output;
+        return $raw_output;
     }
 }


### PR DESCRIPTION
The output handling can fails when API returns non wel JSON formatted response with non-2xx HTTP code (for example, when it returned 500 error with HTML response).

This PR fix that.

Bug created at 7ea5d679cf47edfea1971dd16a8a8b42bf617407.

PR can conflicts with #33, when you merge that I can rebase this PR and resolve the conflict.

